### PR TITLE
[enh] use generic function for symlink creation.

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -43,6 +43,15 @@ check_yunohost_vm() {
     fi
 }
 
+create_sym_link() {
+    # Remove current sources if not a symlink
+    if [ ! -L '$2' ]; then
+        sudo rm -rf $2
+    fi
+    # Symlink from Git repository
+    sudo ln -sfn $1 $2
+}
+
 packages=${@:2}
 if [ "$#" = "1" ]; then
     packages=('moulinette' 'ssowat' 'yunohost' 'yunohost-admin')
@@ -182,36 +191,18 @@ elif [ "$1" = "use-git" ]; then
         case ${packages[i]} in
             ssowat)
                 echo "Using Git repository for SSOwat"
-                # Remove current sources if not a symlink
-                if [ ! -L '/usr/share/ssowat' ]; then
-                    sudo rm -rf /usr/share/ssowat
-                fi
-                # Symlink from Git repository
-                sudo ln -sfn /vagrant/ssowat /usr/share/ssowat
+                create_sym_link "/vagrant/ssowat" "/usr/share/ssowat"
                 echo "↳ Don't forget to do 'sudo yunohost app ssowatconf' when hacking SSOwat"
                 echo ""
                 ;;
             moulinette)
-                if [ ! -L '/usr/share/moulinette/locale' ]; then sudo rm -rf /usr/share/moulinette/locale; fi
-                sudo ln -sfn /vagrant/moulinette/locales /usr/share/moulinette/locale
-
-                if [ ! -L '/usr/lib/python2.7/dist-packages/moulinette/authenticators' ]; then sudo rm -rf /usr/lib/python2.7/dist-packages/moulinette/authenticators; fi
-                sudo ln -sfn /vagrant/moulinette/moulinette/authenticators /usr/lib/python2.7/dist-packages/moulinette/authenticators
-
-                if [ ! -L '/usr/lib/python2.7/dist-packages/moulinette/interfaces' ]; then sudo rm -rf /usr/lib/python2.7/dist-packages/moulinette/interfaces; fi
-                sudo ln -sfn /vagrant/moulinette/moulinette/interfaces /usr/lib/python2.7/dist-packages/moulinette/interfaces
-
-                if [ ! -L '/usr/lib/python2.7/dist-packages/moulinette/utils' ]; then sudo rm -rf /usr/lib/python2.7/dist-packages/moulinette/utils; fi
-                sudo ln -sfn /vagrant/moulinette/moulinette/utils /usr/lib/python2.7/dist-packages/moulinette/utils
-
-                if [ ! -L '/usr/lib/python2.7/dist-packages/moulinette/__init__.py' ]; then sudo rm /usr/lib/python2.7/dist-packages/moulinette/__init__.py; fi
-                sudo ln -sfn /vagrant/moulinette/moulinette/__init__.py /usr/lib/python2.7/dist-packages/moulinette/__init__.py
-
-                if [ ! -L '/usr/lib/python2.7/dist-packages/moulinette/core.py' ]; then sudo rm /usr/lib/python2.7/dist-packages/moulinette/core.py; fi
-                sudo ln -sfn /vagrant/moulinette/moulinette/core.py /usr/lib/python2.7/dist-packages/moulinette/core.py
-
-                if [ ! -L '/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py' ]; then sudo rm /usr/lib/python2.7/dist-packages/moulinette/actionsmap.py; fi
-                sudo ln -sfn /vagrant/moulinette/moulinette/actionsmap.py /usr/lib/python2.7/dist-packages/moulinette/actionsmap.py
+                create_sym_link "/vagrant/moulinette/locales" "/usr/share/moulinette/locale"
+                create_sym_link "/vagrant/moulinette/moulinette/authenticators" "/usr/lib/python2.7/dist-packages/moulinette/authenticator"
+                create_sym_link "/vagrant/moulinette/moulinette/interfaces" "/usr/lib/python2.7/dist-packages/moulinette/interfaces"
+                create_sym_link "/vagrant/moulinette/moulinette/utils" "/usr/lib/python2.7/dist-packages/moulinette/utils"
+                create_sym_link "/vagrant/moulinette/moulinette/__init__.py" "/usr/lib/python2.7/dist-packages/moulinette/__init__.py"
+                create_sym_link "/vagrant/moulinette/moulinette/core.py" "/usr/lib/python2.7/dist-packages/moulinette/core.py"
+                create_sym_link "/vagrant/moulinette/moulinette/actionsmap.py" "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py"
                 echo "↳ If you add files at the root of this directory /vagrant/moulinette/moulinette/ you should adapt ynh-dev"
                 echo ""
                 ;;
@@ -219,50 +210,33 @@ elif [ "$1" = "use-git" ]; then
                 echo "Using Git repository for yunohost"
 
                 # bin
-                if [ ! -L '/usr/bin/yunohost' ]; then sudo rm /usr/bin/yunohost; fi
-                sudo ln -sfn /vagrant/yunohost/bin/yunohost /usr/bin/yunohost
-                if [ ! -L '/usr/bin/yunohost-api' ]; then sudo rm /usr/bin/yunohost-api; fi
-                sudo ln -sfn /vagrant/yunohost/bin/yunohost-api /usr/bin/yunohost-api
+                create_sym_link "/vagrant/yunohost/bin/yunohost" "/usr/bin/yunohost" 
+                create_sym_link "/vagrant/yunohost/bin/yunohost-api" "/usr/bin/yunohost-api"
 
                 # data
-                if [ ! -L '/etc/bash_completion.d/yunohost' ]; then sudo rm /etc/bash_completion.d/yunohost; fi
-                sudo ln -sfn /vagrant/yunohost/data/bash-completion.d/yunohost /etc/bash_completion.d/yunohost
-                if [ ! -L '/usr/share/moulinette/actionsmap/yunohost.yml' ]; then sudo rm /usr/share/moulinette/actionsmap/yunohost.yml; fi
-                sudo ln -sfn /vagrant/yunohost/data/actionsmap/yunohost.yml /usr/share/moulinette/actionsmap/yunohost.yml
-                if [ ! -L '/usr/share/yunohost/hooks' ]; then sudo rm -rf /usr/share/yunohost/hooks; fi
-                sudo ln -sfn /vagrant/yunohost/data/hooks /usr/share/yunohost/hooks
-                if [ ! -L '/usr/share/yunohost/templates' ]; then sudo rm -rf /usr/share/yunohost/templates; fi
-                sudo ln -sfn /vagrant/yunohost/data/templates /usr/share/yunohost/templates
-                if [ ! -L '/usr/share/yunohost/helpers' ]; then sudo rm /usr/share/yunohost/helpers; fi
-                sudo ln -sfn /vagrant/yunohost/data/helpers /usr/share/yunohost/helpers
-                if [ ! -L '/usr/share/yunohost/helpers.d' ]; then sudo rm -rf /usr/share/yunohost/helpers.d; fi
-                sudo ln -sfn /vagrant/yunohost/data/helpers.d /usr/share/yunohost/helpers.d
-                if [ ! -L '/usr/share/yunohost/yunohost-config/moulinette' ]; then sudo rm -rf /usr/share/yunohost/yunohost-config/moulinette; fi
-                sudo ln -sfn /vagrant/yunohost/data/other /usr/share/yunohost/yunohost-config/moulinette
+                create_sym_link "/vagrant/yunohost/data/bash-completion.d/yunohost" "/etc/bash_completion.d/yunohost"
+                create_sym_link "/vagrant/yunohost/data/actionsmap/yunohost.yml" "/usr/share/moulinette/actionsmap/yunohost.yml"
+                create_sym_link "/vagrant/yunohost/data/hooks" "/usr/share/yunohost/hooks"
+                create_sym_link "/vagrant/yunohost/data/templates" "/usr/share/yunohost/templates"
+                create_sym_link "/vagrant/yunohost/data/helpers" "/usr/share/yunohost/helpers"
+                create_sym_link "/vagrant/yunohost/data/helpers.d" "/usr/share/yunohost/helpers.d"
+                create_sym_link "/vagrant/yunohost/data/other" "/usr/share/yunohost/yunohost-config/moulinette"
 
                 # debian
-                if [ ! -L '/usr/share/pam-configs/mkhomedir' ]; then sudo rm /usr/share/pam-configs/mkhomedir; fi
-                sudo ln -sfn /vagrant/yunohost/debian/conf/pam/mkhomedir /usr/share/pam-configs/mkhomedir
+                create_sym_link "/vagrant/yunohost/debian/conf/pam/mkhomedir" "/usr/share/pam-configs/mkhomedir"
 
                 # lib
-                if [ ! -L '/usr/lib/metronome/modules/ldap.lib.lua' ]; then sudo rm /usr/lib/metronome/modules/ldap.lib.lua; fi
-                sudo ln -sfn /vagrant/yunohost/lib/metronome/modules/ldap.lib.lua /usr/lib/metronome/modules/ldap.lib.lua
-                if [ ! -L '/usr/lib/metronome/modules/mod_auth_ldap2.lua' ]; then sudo rm /usr/lib/metronome/modules/mod_auth_ldap2.lua; fi
-                sudo ln -sfn /vagrant/yunohost/lib/metronome/modules/mod_auth_ldap2.lua /usr/lib/metronome/modules/mod_auth_ldap2.lua
-                if [ ! -L '/usr/lib/metronome/modules/mod_legacyauth.lua' ]; then sudo rm /usr/lib/metronome/modules/mod_legacyauth.lua; fi
-                sudo ln -sfn /vagrant/yunohost/lib/metronome/modules/mod_legacyauth.lua /usr/lib/metronome/modules/mod_legacyauth.lua
-                if [ ! -L '/usr/lib/metronome/modules/mod_storage_ldap.lua' ]; then sudo rm /usr/lib/metronome/modules/mod_storage_ldap.lua; fi
-                sudo ln -sfn /vagrant/yunohost/lib/metronome/modules/mod_storage_ldap.lua /usr/lib/metronome/modules/mod_storage_ldap.lua
-                if [ ! -L '/usr/lib/metronome/modules/vcard.lib.lua' ]; then sudo rm /usr/lib/metronome/modules/vcard.lib.lua; fi
-                sudo ln -sfn /vagrant/yunohost/lib/metronome/modules/vcard.lib.lua /usr/lib/metronome/modules/vcard.lib.lua
+                create_sym_link "/vagrant/yunohost/lib/metronome/modules/ldap.lib.lua" "/usr/lib/metronome/modules/ldap.lib.lua"
+                create_sym_link "/vagrant/yunohost/lib/metronome/modules/mod_auth_ldap2.lua" "/usr/lib/metronome/modules/mod_auth_ldap2.lua"
+                create_sym_link "/vagrant/yunohost/lib/metronome/modules/mod_legacyauth.lua" "/usr/lib/metronome/modules/mod_legacyauth.lua"
+                create_sym_link "/vagrant/yunohost/lib/metronome/modules/mod_storage_ldap.lua" "/usr/lib/metronome/modules/mod_storage_ldap.lua"
+                create_sym_link "/vagrant/yunohost/lib/metronome/modules/vcard.lib.lua" "/usr/lib/metronome/modules/vcard.lib.lua"
 
                 # src
-                if [ ! -L '/usr/lib/moulinette/yunohost' ]; then sudo rm -rf /usr/lib/moulinette/yunohost; fi
-                sudo ln -sfn /vagrant/yunohost/src/yunohost /usr/lib/moulinette/yunohost
+                create_sym_link "/vagrant/yunohost/src/yunohost" "/usr/lib/moulinette/yunohost"
 
                 # locales
-                if [ ! -L '/usr/lib/moulinette/yunohost/locales' ]; then sudo rm -rf /usr/lib/moulinette/yunohost/locales; fi
-                sudo ln -sfn /vagrant/yunohost/locales /usr/lib/moulinette/yunohost/locales
+                create_sym_link "/vagrant/yunohost/locales" "/usr/lib/moulinette/yunohost/locales"
 
                 echo ""
                 ;;
@@ -291,12 +265,7 @@ elif [ "$1" = "use-git" ]; then
                 sudo su -c "gulp build --dev" vagrant
 
                 echo "Using Git repository for yunohost-admin"
-                # Remove current sources if not a symlink
-                if [ ! -L '/usr/share/yunohost/admin' ]; then
-                    sudo rm -rf /usr/share/yunohost/admin
-                fi
-                # Symlink from Git repository
-                sudo ln -sfn /vagrant/yunohost-admin/src /usr/share/yunohost/admin
+                create_sym_link "/vagrant/yunohost-admin/src" "/usr/share/yunohost/admin"
 
                 echo "--------------------------------------------------------"
                 echo "Launching gulp ... "


### PR DESCRIPTION
Simplify the code using a generic function for symlink creation.
I tested for SSOwat, yunohost and moulinette packages and it works perfectly.