### PR TITLE
[fix] Cant create multiple vm (Redmine 931)

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -157,6 +157,17 @@ elif [ "$1" = "run" ]; then
             }
         done
 
+        # Update Vagrantfile
+        grep "### END AUTOMATIC YNH-DEV ###" ./Vagrantfile &> /dev/null || {
+            pushd ./vagrant &> /dev/null
+            git pull
+            popd &> /dev/null
+            rm ./Vagrantfile
+            ln -s vagrant/Vagrantfile Vagrantfile
+
+        }
+
+        # Adapt vagrantfile
         sed -i "/  ### END AUTOMATIC YNH-DEV ###/ i \\
   config.vm.define \"${VMNAME}\" do |${VMNAME}| \
 \n    ${VMNAME}.vm.box = \"yunohost/jessie-${VERSION}\" \
@@ -173,8 +184,7 @@ VERSION as stable, testing or unstable /!\ "
 
     # Warn user about hosts file
     IP_LINE="\s\s*${VMNAME}.vm.network\s\s*:private_network,\s*ip:\s*\""
-    IP=$(grep "$IP_LINE" Vagrantfile | sed "s/${IP_LINE}//")
-    IP=${IP::-1}
+    IP=$(grep "$IP_LINE" Vagrantfile | sed "s/${IP_LINE}//" | tr -d '"')
     echo "/!\ Please add '$IP $DOMAIN' to your /etc/hosts file /!\\"
     echo "sudo sh -s 'echo \"$IP $DOMAIN\" >> /etc/hosts'"
     echo ""

--- a/ynh-dev
+++ b/ynh-dev
@@ -166,7 +166,7 @@ elif [ "$1" = "run" ]; then
     }
 
     # Run VM
-    vagrant up $VERSION --provider virtualbox
+    vagrant up $VMNAME --provider virtualbox
 
     # Warn user about hosts file
     IP_LINE="\s\s*${VMNAME}.vm.network\s\s*:private_network,\s*ip:\s*\""
@@ -177,7 +177,7 @@ elif [ "$1" = "run" ]; then
     echo ""
 
     # Log into the VM
-    vagrant ssh $VERSION
+    vagrant ssh $VMNAME
 
 
 #####################

--- a/ynh-dev
+++ b/ynh-dev
@@ -166,6 +166,9 @@ elif [ "$1" = "run" ]; then
     }
 
     # Run VM
+    echo "/!\ If you don't refund an old vm, may be the vm has been \
+accidentally named with the VERSION, try to run 'ynh-dev run VERSION' with \
+VERSION as stable, testing or unstable /!\ "
     vagrant up $VMNAME --provider virtualbox
 
     # Warn user about hosts file


### PR DESCRIPTION
Allow to run several VM with the same box origin.

IMPORTANT: this fix break some retro compatibility:
If before you have done
`ynh-dev run toto.local unstable`
With this script you can't get back to the vm with the same command, but you can do this with:
`ynh-dev run unstable unstable`


Use case: 
Be able to test openvpn_ynh with vpnclient_ynh (2 vm needed).
Be able to code on "federated" yunohost (friend backup ...)
Test the good creation of vm (creation, update, postinstall)
Be able to keep a vm with change (app packaging process... try first, write in the install script next...)

https://dev.yunohost.org/issues/931
