### PR TITLE
[fix] Missing dependency: mock

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -338,7 +338,7 @@ elif [ "$1" = "test" ]; then
                     apt-get install python-pip
                     pip2 install pytest
                 fi
-                PIP_DEPENDENCIES="pytest-mock requests-mock"
+                PIP_DEPENDENCIES="pytest-mock requests-mock mock"
                 for DEP in $PIP_DEPENDENCIES
                 do
                     if [ -z "$(pip show $DEP)" ]; then


### PR DESCRIPTION
## Problem
A small dependency is missing. Without it the yunohost backup tests fail.

## Solution
Just add the mock dependency

## PR Status
Work finished

## Validation
Micro decision, I mark it as ready to merge

