### PR TITLE
[enh] Be able to select which test executes

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -19,7 +19,7 @@ Usage :
             Upgrade the container
         `basename $0` use-git [PACKAGES [PACKAGES ...]]
             Use Git repositories from dev environment path
-        `basename $0` test [PACKAGES [PACKAGES ...]]
+        `basename $0` test [PACKAGES[/TESTFILE[::TEST]] [PACKAGES[/TESTFILE[::TEST]] ...]]
             Deploy, update and run tests for some packages
         `basename $0` self-update
             Update this script (`basename $0`)

--- a/ynh-dev
+++ b/ynh-dev
@@ -328,7 +328,13 @@ elif [ "$1" = "test" ]; then
     VERSION=$2
 
     for i in ${!packages[@]}; do
-        case ${packages[i]} in
+        package=$(echo ${packages[i]} | cut -d/ -f1)
+        selection=$(echo ${packages[i]} | cut -d/ -f2)
+        if [ "$selection" = "yunohost" ]; then
+            selection=""
+        fi
+
+        case $package in
             yunohost)
                 # Pytest and tests dependencies
                 if ! type "pytest" > /dev/null; then
@@ -363,7 +369,7 @@ elif [ "$1" = "test" ]; then
                 cd /vagrant/yunohost/
                 py.test tests
                 cd /vagrant/yunohost/src/yunohost
-                py.test tests
+                py.test tests/$selection
                 ;;
         esac
     done


### PR DESCRIPTION
## Problem
Test on yunohost/yunohost are long now. We need a quicker way to run them.

## Solution
I suggest a feature to select which tests execute. cf https://dev.yunohost.org/issues/990

## How to test
You can for example run something like 
```
./ynh-dev test yunohost/test_backuprestore.py::test_restore_system_from_Ynh2p4
```
OR
```
./ynh-dev test yunohost/test_backuprestore.py
```

## PR Status
Work finished

## Validation
*Minor decision*
- [ ] **Simple test** : 
- [ ] **Light Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.
