### PR TITLE
[enh] Add unstable stretch box

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -129,6 +129,9 @@ elif [ "$1" = "run" ]; then
     elif [ "$VERSION" = "unstable" ]; then
         BOX_NAME="yunohost/jessie-unstable"
         BOX_URL="https://build.yunohost.org/yunohost-jessie-unstable.box"
+    elif [ "$VERSION" = "stretch-unstable" ]; then
+        BOX_NAME="yunohost/stretch-unstable"
+        BOX_URL="https://build.yunohost.org/yunohost-stretch-unstable.box"
     else
         echo "ERROR: Incorrect version '$VERSION'. See '$(basename $0) --help' for usage."
         exit 102
@@ -170,7 +173,7 @@ elif [ "$1" = "run" ]; then
         # Adapt vagrantfile
         sed -i "/  ### END AUTOMATIC YNH-DEV ###/ i \\
   config.vm.define \"${VMNAME}\" do |${VMNAME}| \
-\n    ${VMNAME}.vm.box = \"yunohost/jessie-${VERSION}\" \
+\n    ${VMNAME}.vm.box = \"${BOX_NAME}\" \
 \n    ${VMNAME}.vm.network :private_network, ip: \"${IP}\" \
 \n  end \
 \n" ./Vagrantfile


### PR DESCRIPTION
Hey there,

I managed to create an unstable stretch box with Yunohost pre-installed (from branch stretch). This should make things much easier to test and develop on stretch. 

This was built with some pretty dirty recipes from https://github.com/YunoHost/Vagrantfile/tree/stretch/prebuild and https://github.com/YunoHost/install_script/tree/stretch . These should get cleaner as we start putting the right infrastructure in place (e.g. building proper debian packages).

On this image, at this point you should be able to postinstall and perform basic operations on users and domains. Apps not tested yet. See the todo [on this pad](https://pad.aposti.net/p/ynh-stretch). I haven't really tested `ynh-dev use-git` for now, but this should be fine as long as your branch is based on the `stretch` branch somehow.

Feedback is welcome if you notice some bugs with the box !