### PR TITLE
Small changes to support Windows/Busybox

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -296,7 +296,7 @@ elif [ "$1" = "use-git" ]; then
                     sudo apt-get update --fix-missing
                     sudo apt-get -y install nodejs-legacy npm
                     cd /vagrant/yunohost-admin/src
-                    sudo npm install
+                    sudo npm install --no-bin-links
                     sudo npm install -g bower
                     sudo npm install -g gulp
                 fi

--- a/ynh-dev
+++ b/ynh-dev
@@ -98,7 +98,7 @@ elif [ "$1" = "create-env" ]; then
 
     # Get YunoHost Vagrantfile
     git clone -b master https://github.com/YunoHost/Vagrantfile vagrant
-    ln -s vagrant/Vagrantfile Vagrantfile
+    cp vagrant/Vagrantfile Vagrantfile
 
     # Get YunoHost dev tools
     git clone -b master https://github.com/YunoHost/ynh-dev ynh-dev-tools
@@ -163,17 +163,17 @@ elif [ "$1" = "run" ]; then
             git pull
             popd &> /dev/null
             rm ./Vagrantfile
-            ln -s vagrant/Vagrantfile Vagrantfile
+            cp vagrant/Vagrantfile Vagrantfile
 
         }
 
         # Adapt vagrantfile
         sed -i "/  ### END AUTOMATIC YNH-DEV ###/ i \\
-  config.vm.define \"${VMNAME}\" do |${VMNAME}| \
-\n    ${VMNAME}.vm.box = \"yunohost/jessie-${VERSION}\" \
-\n    ${VMNAME}.vm.network :private_network, ip: \"${IP}\" \
-\n  end \
-\n" ./Vagrantfile
+  config.vm.define \"${VMNAME}\" do |${VMNAME}| \\
+    ${VMNAME}.vm.box = \"yunohost/jessie-${VERSION}\" \\
+    ${VMNAME}.vm.network :private_network, ip: \"${IP}\" \\
+  end \\
+" ./Vagrantfile
     }
 
     # Run VM


### PR DESCRIPTION
In order to be compatible with Windows/BusyBox
* don't rely on symbolic links on the host
  * don't use them in the `ynh-dev` script
  * use `--no-bin-links` option for `npm install` (this option has been specifically introduced for this case, see [here](https://github.com/npm/npm/issues/2380))
* apply a slight change to a sed command (no "\n")

Note: I use MobaXterm, VirtualBox 64 bits and Vagrant 32 bits (because MobaXterm is 32 bits).