### PR TITLE
[enh] use 'root' user after ssh authentication

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -194,7 +194,7 @@ VERSION as stable, testing or unstable /!\ "
     echo ""
 
     # Log into the VM
-    vagrant ssh $VMNAME
+    vagrant ssh $VMNAME -c "sudo -i"
 
 
 #####################


### PR DESCRIPTION
I tried to move directly in `/vagrant` folder but it doesn't works with:

```bash
vagrant ssh $VMNAME -c "sudo -i; cd /vagrant"
```