### PR TITLE
Fix macOS/BSD portability

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -190,7 +190,7 @@ VERSION as stable, testing or unstable /!\ "
     vagrant up $VMNAME --provider virtualbox
 
     # Warn user about hosts file
-    IP_LINE="\s\s*${VMNAME}.vm.network\s\s*:private_network,\s*ip:\s*\""
+    IP_LINE="[[:space:]]*${VMNAME}.vm.network[[:space:]]*:private_network,[[:space:]]*ip:[[:space:]]*\""
     IP=$(grep "$IP_LINE" Vagrantfile | sed "s/${IP_LINE}//" | tr -d '"')
     echo "/!\ Please add '$IP $DOMAIN' to your /etc/hosts file /!\\"
     echo "sudo bash -c 'echo \"$IP $DOMAIN\" >> /etc/hosts'"

--- a/ynh-dev
+++ b/ynh-dev
@@ -175,12 +175,12 @@ elif [ "$1" = "run" ]; then
         }
 
         # Adapt vagrantfile
-        sed -i "/  ### END AUTOMATIC YNH-DEV ###/ i \\
-  config.vm.define \"${VMNAME}\" do |${VMNAME}| \
+        perl -i -pe "s|  (### END AUTOMATIC YNH-DEV ###)|\
+  config.vm.define \"${VMNAME}\" do \|${VMNAME}\| \
 \n    ${VMNAME}.vm.box = \"${BOX_NAME}\" \
 \n    ${VMNAME}.vm.network :private_network, ip: \"${IP}\" \
 \n  end \
-\n" ./Vagrantfile
+\n  \1|" ./Vagrantfile
     }
 
     # Run VM


### PR DESCRIPTION
Fix several issues encountered when running `./ynh-dev run ynhdev.local stable` on macOS.

### Fix Vagrantfile in-place editing

* Unlike GNU-sed, BSD-sed `-i` option requires an explicit backup
  extension.
* Newlines are difficult to get right on different versions of `sed`.

This commit replaces the `sed` invocation with `perl`. It does the same job with almost the same syntax, but avoids portability issues.

### Fix IP retrieval

`\s` for matching spaces is a GNU-sed extension. The portable way is to use `[[:space]]` instead.
