### PR TITLE
Remove old warning about previous behavior

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -184,9 +184,6 @@ elif [ "$1" = "run" ]; then
     }
 
     # Run VM
-    echo "/!\ If you don't refund an old vm, may be the vm has been \
-accidentally named with the VERSION, try to run 'ynh-dev run VERSION' with \
-VERSION as stable, testing or unstable /!\ "
     vagrant up $VMNAME --provider virtualbox
 
     # Warn user about hosts file


### PR DESCRIPTION
It's been 7 months now, so that's probably not relevant anymore and might generate confusion for new users of this tool 😉 