### PR TITLE
[fix] support stretch for npm/gulp

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -283,8 +283,19 @@ elif [ "$1" = "use-git" ]; then
                 which gulp > /dev/null
                 if [ $? -eq 1 ]
                 then
-                    sudo apt-get update --fix-missing
-                    sudo apt-get -y install nodejs-legacy npm
+                    release=$(lsb_release -c | cut -d ":" -f 2 | sed 's/\s*//')
+
+                    if [ $release == "stretch" ]
+                    then
+                        # for watever reason npm is not in stretch anymore
+                        # because why the fuck debian
+                        curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+                        sudo apt install nodejs
+                    else
+                        sudo apt-get update --fix-missing
+                        sudo apt-get -y install nodejs-legacy npm
+                    fi
+
                     cd /vagrant/yunohost-admin/src
                     sudo npm install
                     sudo npm install -g bower


### PR DESCRIPTION
Debian is doing debian things again so now npm is not present in stretch for whatever reason that I don't want to know.

This code handles running `./ynh-dev use-git yunohost-admin` on both stretch and jessie.

Testing and working for me.