### PR TITLE
Add .vagrant in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 vagrant
 ynh-dev-tools
 Vagrantfile
+.vagrant
 
 # Sources repositories
 moulinette


### PR DESCRIPTION
I've added the line ".vagrant" in the gitignore because vagrant create this file which is not included in the repo, when we follow the "how to contribute" documentation.