### PR TITLE
Point to default language page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,4 +170,4 @@ any `yunohost` command will run from the code of the git clone. The `use-git` ac
 
 ## More info
 
-[yunohost.org/dev_fr](https://yunohost.org/dev_fr) (in french) not up-to-date.
+* [yunohost.org/dev](https://yunohost.org/dev) not up-to-date.


### PR DESCRIPTION
Closes https://github.com/YunoHost/issues/issues/1352.

Someone with permissions would have to edit the repository description to change that link as well. Please see https://github.com/YunoHost/issues/issues/1352#issue-445832752 for mroe on that.