### PR TITLE
Add missing step installing lxd

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ be able to install `snapd` using the system package manager (or even
 
 ```bash
 apt install git snapd
+sudo snap install core
 sudo snap install lxd
 
 # Adding lxc/lxd to /usr/local/bin to make sure we can use them easily even


### PR DESCRIPTION
on debian buster at least. Avoir enigmatic message : 

See https://forum.snapcraft.io/t/snap-lxd-assumes-unsupported-features-snapd2-39/17542/6