### PR TITLE
Port to Vue.js (dev setup)

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -230,7 +230,10 @@ function use_git()
                 # bin
                 create_sym_link "/ynh-dev/yunohost/bin/yunohost" "/usr/bin/yunohost"
                 create_sym_link "/ynh-dev/yunohost/bin/yunohost-api" "/usr/bin/yunohost-api"
-
+                create_sym_link "/ynh-dev/yunohost/bin/yunoprompt" "/usr/bin/yunoprompt"
+                create_sym_link "/ynh-dev/yunohost/bin/yunopaste" "/usr/bin/yunopaste"
+                create_sym_link "/ynh-dev/yunohost/sbin/yunohost-reset-ldap-password" "/usr/sbin/yunohost-reset-ldap-password"
+                
                 # data
                 create_sym_link "/ynh-dev/yunohost/data/bash-completion.d/yunohost" "/etc/bash_completion.d/yunohost"
                 create_sym_link "/ynh-dev/yunohost/data/actionsmap/yunohost.yml" "/usr/share/moulinette/actionsmap/yunohost.yml"

--- a/ynh-dev
+++ b/ynh-dev
@@ -166,6 +166,13 @@ function attach_ynhdev()
         ln -s /var/cache/ynh-dev/yunohost-admin/dist ./yunohost-admin/src/
     fi
 
+    # Setup symlinks for future .env and nodes_modules/ for yunohost-admin-vue
+    if [[ ! -L ./yunohost-admin-vue/app/.env ]]
+    then
+        ln -s /var/cache/ynh-dev/yunohost-admin/.env ./yunohost-admin-vue/app
+        ln -s /var/cache/ynh-dev/yunohost-admin/node_modules ./yunohost-admin-vue/app/
+    fi
+
     check_lxd_setup
     local BOX=${1:-ynh-dev-buster}
     sudo lxc start $BOX 2>/dev/null || true
@@ -233,7 +240,7 @@ function use_git()
                 create_sym_link "/ynh-dev/yunohost/bin/yunoprompt" "/usr/bin/yunoprompt"
                 create_sym_link "/ynh-dev/yunohost/bin/yunopaste" "/usr/bin/yunopaste"
                 create_sym_link "/ynh-dev/yunohost/sbin/yunohost-reset-ldap-password" "/usr/sbin/yunohost-reset-ldap-password"
-                
+
                 # data
                 create_sym_link "/ynh-dev/yunohost/data/bash-completion.d/yunohost" "/etc/bash_completion.d/yunohost"
                 create_sym_link "/ynh-dev/yunohost/data/actionsmap/yunohost.yml" "/usr/share/moulinette/actionsmap/yunohost.yml"
@@ -310,6 +317,59 @@ function use_git()
                 warn "-------------------------------------------------------- "
                 su ynhdev -c "./node_modules/gulp/bin/gulp.js watch --dev"
 
+                ;;
+            yunohost-admin-vue)
+                getent passwd ynhdev > /dev/null
+                if [ $? -eq 2 ]; then
+                    useradd ynhdev
+                fi
+
+                mkdir -p /var/cache/ynh-dev/yunohost-admin/
+                # mkdir -p /var/cache/ynh-dev/yunohost-admin/dist
+                chown -R ynhdev /var/cache/ynh-dev/yunohost-admin/
+                create_sym_link "/ynh-dev/yunohost-admin-vue/app/package.json" "/var/cache/ynh-dev/yunohost-admin/package.json"
+                create_sym_link "/ynh-dev/yunohost-admin-vue/app/package-lock.json" "/var/cache/ynh-dev/yunohost-admin/package-lock.json"
+                # create_sym_link "/ynh-dev/yunohost-admin-vue/app" "/usr/share/yunohost/admin"
+
+                cd /var/cache/ynh-dev/yunohost-admin/
+                # Create .env file with the vm ip
+                # Will be used by webpack-dev-server to proxy api requests.
+                if [[ ! -e .env ]]
+                then
+                    info "Creating .env file"
+                    IP=$(hostname -I | tr ' ' '\n' | grep "\.")
+                    echo "VUE_APP_IP=$IP" > .env
+                fi
+
+                # Allow port 8080 in config file or else the dev server will stop working after postinstall
+                if [[ ! -e /etc/yunohost/installed ]]
+                then
+                    python2.7 - <<EOF
+import os, yaml
+setting_file = "/etc/yunohost/firewall.yml"
+assert os.path.exists(setting_file), "Firewall yaml file %s does not exists ?" % setting_file
+with open(setting_file) as f:
+    settings = yaml.load(f)
+    if 8080 not in settings["ipv4"]["TCP"]:
+        settings["ipv4"]["TCP"].append(8080)
+        with open(setting_file, "w") as f:
+            yaml.safe_dump(settings, f, default_flow_style=False)
+EOF
+                fi
+
+                # Install npm if needed
+                if [[ ! -e node_modules/@vue/cli-service/bin/vue-cli-service.js ]]
+                then
+                    info "Installing dependencies to develop in yunohost-admin ..."
+                    apt install nodejs npm -y
+                    npm install -g npm@latest
+                fi
+
+                # Install dependencies
+                npm ci --no-bin-links
+                success "Now using Git repository for yunohost-admin"
+                cd /ynh-dev/yunohost-admin-vue/app/
+                npm run serve
                 ;;
         esac
     done

--- a/ynh-dev
+++ b/ynh-dev
@@ -226,7 +226,7 @@ function use_git()
         PACKAGES=('moulinette' 'ssowat' 'yunohost' 'yunohost-admin')
     fi
 
-    for i in ${!PACKAGES[@]};
+    for i in "${!PACKAGES[@]}";
     do
         case ${PACKAGES[i]} in
             ssowat)
@@ -277,54 +277,6 @@ function use_git()
                 ;;
             yunohost-admin)
 
-                getent passwd ynhdev > /dev/null
-                if [ $? -eq 2 ]; then
-                    useradd ynhdev
-                fi
-
-                mkdir -p /var/cache/ynh-dev/yunohost-admin/
-                mkdir -p /var/cache/ynh-dev/yunohost-admin/dist
-                chown -R ynhdev /var/cache/ynh-dev/yunohost-admin/
-                create_sym_link "/ynh-dev/yunohost-admin/src/package.json" "/var/cache/ynh-dev/yunohost-admin/package.json"
-                create_sym_link "/ynh-dev/yunohost-admin/src/package-lock.json" "/var/cache/ynh-dev/yunohost-admin/package-lock.json"
-                create_sym_link "/ynh-dev/yunohost-admin/src" "/usr/share/yunohost/admin"
-
-                if [ ! -e /ynh-dev/yunohost-admin/src/dist ]
-                then
-                    echo "If npm install fails to create the dist and node_modules folder, maybe you need to run the following *in the host!* : "
-                    echo " "
-                    echo "cd /your/dev/env/yunohost-admin/src/"
-                    echo "ln -s /var/cache/ynh-dev/yunohost-admin/dist ./dist"
-                    echo "ln -s /var/cache/ynh-dev/yunohost-admin/node_modules ./node_modules"
-                    echo " "
-                fi
-
-                # Install npm dependencies if needed
-                cd /var/cache/ynh-dev/yunohost-admin/
-                if [ ! -e node_modules/gulp/bin/gulp.js ]
-                then
-                    info "Installing dependencies to develop in yunohost-admin ..."
-                    apt install nodejs npm -y
-                    npm install -g npm@latest
-                fi
-
-                npm ci --no-bin-links
-
-                success "Now using Git repository for yunohost-admin"
-
-                cd /ynh-dev/yunohost-admin/src
-                su ynhdev -c "./node_modules/gulp/bin/gulp.js build --dev"
-                warn "-------------------------------------------------------- "
-                warn "Launching gulp ...                                       "
-                warn "NB : This command will keep running and watch for changes"
-                warn " in the folder /ynh-dev/yunohost-admin/src, such that you"
-                warn "don't need to re-run npm yourself everytime you change   "
-                warn "something !                                              "
-                warn "-------------------------------------------------------- "
-                su ynhdev -c "./node_modules/gulp/bin/gulp.js watch --dev"
-
-                ;;
-            yunohost-admin-vue)
                 getent passwd ynhdev > /dev/null
                 if [ $? -eq 2 ]; then
                     useradd ynhdev
@@ -401,6 +353,7 @@ EOF
                 systemctl reload nginx
                 cd /ynh-dev/yunohost-admin-vue/app/
                 npm run serve
+                ;;
             *)
                 error "Invalid package '${PACKAGES[i]}': correct arguments are 'yunohost', 'ssowat', 'moulinette', 'yunohost-admin' or nothing for all"
                 ;;
@@ -412,7 +365,7 @@ function run_tests()
 {
     assert_inside_vm
     local PACKAGES="$@"
-    for PACKAGE in "$PACKAGES";
+    for PACKAGE in $PACKAGES;
     do
         TEST_FUNCTION=$(echo "$PACKAGE" | tr '/:' ' ' | awk '{print $3}')
         TEST_MODULE=$(echo "$PACKAGE" | tr '/:' ' ' | awk '{print $2}')
@@ -463,4 +416,4 @@ function run_tests()
     done
 }
 
-main $@
+main "$@"


### PR DESCRIPTION
For now it's not an overwrite of the current command to run yunohost-admin dev environment, it's another command => `./ynh-dev use-git yunohost-admin-vue` with another clone.  
The command adds the port `8080` in the firewall opened ports because we use webpack-dev-server. This allows hot-reloads and bunch of features (there is no need to fully rebuild the js at each file modification).
The command also creates a `.env` file with the lxc IP so the webpack-dev-server can proxy API requests.  

## PR Status
??

## How to test
You need to add another repo in `ynh-dev/` so we can switch between old/new versions.
```bash
# from `ynh-dev/`
git clone -b enh-vuejs --single-branch https://github.com/Axolotle/yunohost-admin yunohost-admin-vue

# from the lxc
./ynh-dev use-git yunohost-admin-vue
```