### PR TITLE
Update Incus installation for older distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,8 @@ Incus can be installed on Debian 13 or Ubuntu 24.04 with the command:
 apt install incus
 ```
 
-If you have an older dsitribution, the installation can be made by following the
-installation guide(https://github.com/zabbly/incus):
-
-```bash
-mkdir -p /etc/apt/keyrings/
-curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
-```
+If you have an older distribution, you need to add the Zabbly repositry to your package manager.
+To do so please follow the installation guide that you can find on https://github.com/zabbly/incus.
 
 You then need to add yourself in the incus-admin group, to run incus without sudo every time:
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ First you need to install the system dependencies.
 libvirt or vanilla LXCs**, especially because they all require a daemon based
 on DNSmasq and therefore require to listen on port 53.
 
-Incus can be installed on Debian 13 or Ubuntu 24.04 with the command:
+Incus can be installed on Debian 13 or Ubuntu 24.04 with the following command:
 
 ```bash
 apt install incus
 ```
 
-If you have an older distribution, you need to add the Zabbly repositry to your package manager.
-To do so please follow the installation guide that you can find on https://github.com/zabbly/incus.
+If you have an older distribution, you need to add the Zabbly repositry to your package manager.  
+To do so please follow the installation guide that you can find on <https://github.com/zabbly/incus>.
 
 You then need to add yourself in the incus-admin group, to run incus without sudo every time:
 

--- a/README.md
+++ b/README.md
@@ -112,10 +112,18 @@ First you need to install the system dependencies.
 libvirt or vanilla LXCs**, especially because they all require a daemon based
 on DNSmasq and therefore require to listen on port 53.
 
-Incus can be installed with your Linux distribution package manager, such as:
+Incus can be installed on Debian 13 or Ubuntu 24.04 with the command:
 
 ```bash
 apt install incus
+```
+
+If you have an older dsitribution, the installation can be made by following the
+installation guide(https://github.com/zabbly/incus):
+
+```bash
+mkdir -p /etc/apt/keyrings/
+curl -fsSL https://pkgs.zabbly.com/key.asc -o /etc/apt/keyrings/zabbly.asc
 ```
 
 You then need to add yourself in the incus-admin group, to run incus without sudo every time:


### PR DESCRIPTION
The current Incus installation works only for Debian 13 or Ubuntu 24.04.
The documentation is updated to take into account that some people have older distros