### PR TITLE
More portable dependency checks

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -180,7 +180,7 @@ function prepare_cache_and_deps() {
 function check_incus_setup()
 {
     # Check incus is installed somehow
-    if ! which incus &>/dev/null; then
+    if ! command -v incus &>/dev/null; then
         critical "You need to have Incus installed for ynh-dev to be usable from the host machine. Refer to the README to know how to install it."
     fi
     if ! id -nG "$(whoami)" | grep -qw "incus-admin"; then
@@ -455,7 +455,7 @@ function dev()
 {
     assert_inside_vm
 
-    which inotifywait &>/dev/null || critical "You should first run: apt install inotify-tools"
+    command -v inotifywait &>/dev/null || critical "You should first run: apt install inotify-tools"
 
     info "Now monitoring for changes in python files, restarting yunohost-api and yunohost-portal-api when changes occur!"
 

--- a/ynh-dev
+++ b/ynh-dev
@@ -183,7 +183,7 @@ function check_incus_setup()
     if ! command -v incus &>/dev/null; then
         critical "You need to have Incus installed for ynh-dev to be usable from the host machine. Refer to the README to know how to install it."
     fi
-    if ! id -nG "$(whoami)" | grep -qw "incus-admin"; then
+    if ! id -nG "$(whoami)" | grep -qw "incus-admin" && [ ! $(id -u) -eq 0 ]; then
         critical "You need to be in the incus-admin group!"
     fi
 

--- a/ynh-dev
+++ b/ynh-dev
@@ -195,6 +195,11 @@ function check_incus_setup()
 
 function set_incus_remote()
 {
+    # Check jq is installed somehow
+    if ! command -v jq &>/dev/null; then
+        critical "You need jq installed for ynh-dev"
+    fi
+
     configured=$(incus remote list -f json | jq 'has("yunohost")')
     if [[ "$configured" != "true" ]]; then
         incus remote add yunohost https://devbaseimgs.yunohost.org --public


### PR DESCRIPTION
- use command instead of which (archlinux doesn't have which installed by default, command is POSIX compliant)
- root user doesn't need to be in `incus-admin` group
- jq is also a dependency