### PR TITLE
Run dhcp client after startup

### DIFF
--- a/ynh-dev
+++ b/ynh-dev
@@ -214,6 +214,8 @@ function start_ynhdev()
         info "Attaching to existing container"
     fi
 
+    incus exec "$BOX" dhclient
+
     attach_ynhdev "$@"
 }
 


### PR DESCRIPTION
As discussed (here)[https://github.com/YunoHost/issues/issues/2463], the DNS name resolution is not working inside the LXC container. This is due to a missing DHCP client so the upstream DNS server is never configured.

Running `dhclient` after startup fixes this issue.

I'm however not sure if this is the most elegant solution.

Fixes https://github.com/YunoHost/issues/issues/2463