### PR TITLE
improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ If you want to access to the interface using the domain name, you shall tweak yo
 111.222.333.444 yolo.test
 ```
 
+If the web interface show an error about unresponding Yunohost API, you can start it with:
+
+```bash
+sudo systemctl restart yunohost-api
+```
+
 Note that `./ynh-dev use-git yunohost-admin` has a particular behavior: it starts a `gulp` watcher
 that shall re-compile automatically any changes in the javascript code. Hence this particular `use-git`
 will keep running until you kill it after your work is done.

--- a/README.md
+++ b/README.md
@@ -120,17 +120,16 @@ You then need to add yourself in the incus-admin group, to run incus without sud
 sudo usermod -a -G incus-admin $(whoami)
 ```
 
-Now the group incus-admin should be present when you type the command:
+If you restart your session the group incus-admin should be present when you type the command:
 
 ```bash
 groups
 ```
 
-If not you need to create the group first:
+Instead of restarting your session, you can login into the group:
 
 ```bash
 newgrp incus-admin
-sudo usermod -a -G incus-admin $(whoami)
 ```
 
 Then you shall initialize Incus which will ask you a bunch of question. Usually


### PR DESCRIPTION
correct text about the `newgrp` command (that doesn't create a group but login into a newly created group instead of restarting the shell session)

add command to start the yunohost API if needed after the very first setup